### PR TITLE
Fix attribute name to be type

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@ google_auto_ads: false
 	<head>
 
 		<meta charset="utf-8">
-		<link rel="preload" href="/fonts/metro.woff" as="font" href="font/woff" crossorigin>
+		<link rel="preload" href="/fonts/metro.woff" as="font" type="font/woff" crossorigin>
 
 		<link rel="shortcut icon" href="/favicon.ico">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
The default layout preloads the `metro.woff` font. Its type `font/woff` is declared via a second `href=` attribute, wich should be a `type=` attribute instead.