### PR TITLE
fix damage wiki page with correct limits

### DIFF
--- a/_wiki/Commands/damage.md
+++ b/_wiki/Commands/damage.md
@@ -5,10 +5,10 @@ labels:
   - messy
 ---
 ## Overview
-Applies the given amount of damage. The amount of damage must be a number between 1 and 40. This works on both normal servers and NoCheat+ servers, as long as they have fall damage enabled.
+Applies the given amount of damage. The amount of damage must be a number between 1 and 7. This works on both normal servers and NoCheat+ servers, as long as they have fall damage enabled.
 
 ## Syntax
 `.damage <amount>` damages the player with the given amount.
 
 ## Example
-`.damage 8` deals 8 damage points (4 hearts) to the player.
+`.damage 7` deals 7 damage points (3.5 hearts) to the player.


### PR DESCRIPTION
Wurst currently only allows `.damage` to deal only 7 damage points. But the wiki page says you can deal up to 40. Gonna maybe send a PR that sets it back to 40 when I find out how to set up the source code.